### PR TITLE
Remove functions field from Create Microservice form

### DIFF
--- a/src/components/FormCreateMicroservice.vue
+++ b/src/components/FormCreateMicroservice.vue
@@ -24,7 +24,7 @@
 
       <!-- Selección de servicio -->
       <v-select
-        v-model="selectedServiceId"
+        v-model="microservicesStore.form.service_id"
         :items="availableServices"
         item-title="name"
         item-value="service_id"
@@ -59,19 +59,6 @@
           />
         </v-col>
       </v-row>
-
-      <!-- Funciones asociadas -->
-      <v-select
-        v-model="selectedFunctions"
-        :items="availableFunctions"
-        item-title="name"
-        item-value="function_id"
-        label="Functions"
-        variant="filled"
-        multiple
-        chips
-        prepend-inner-icon="mdi-function"
-      />
 
       <!-- Botón Guardar -->
       <div class="d-flex mt-4">
@@ -109,21 +96,15 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, onBeforeRouteUpdate } from 'vue-router'
 import { useMicroservicesStore } from '@/store/microservices'
 import { useServicesStore } from '@/store/services'
-import { useFunctionsStore } from '@/store/functions'
 
 const microservicesStore = useMicroservicesStore()
 const servicesStore = useServicesStore()
-const functionsStore = useFunctionsStore()
 
-const selectedServiceId = ref('')
-const selectedFunctions = ref([])
 const availableServices = ref([])
-const availableFunctions = ref([])
-
 const isValid = ref(false)
 const formRef = ref(null)
 const isEditing = ref(false)
@@ -140,15 +121,6 @@ const rules = {
 
 const route = useRoute()
 
-// --- Sincronizar selectedServiceId y selectedFunctions con form ---
-watch(selectedServiceId, (newId) => {
-  microservicesStore.form.service_id = newId
-})
-
-watch(selectedFunctions, (newFuncs) => {
-  microservicesStore.form.functions = newFuncs
-})
-
 // --- Cargar formulario ---
 const loadForm = (editQuery) => {
   if (editQuery) {
@@ -156,14 +128,10 @@ const loadForm = (editQuery) => {
     const msToEdit = microservicesStore.microservices.find(m => m.microservice_id === editQuery)
     if (msToEdit) {
       microservicesStore.form = { ...msToEdit }
-      selectedServiceId.value = msToEdit.service_id || ''
-      selectedFunctions.value = msToEdit.functions || []
     }
   } else {
     isEditing.value = false
     microservicesStore.resetForm()
-    selectedServiceId.value = ''
-    selectedFunctions.value = []
     formRef.value.resetValidation()
     isValid.value = false
   }
@@ -173,10 +141,6 @@ const loadForm = (editQuery) => {
 onMounted(async () => {
   await servicesStore.get_services()
   availableServices.value = servicesStore.services.map(s => ({ service_id: s.service_id, name: s.name }))
-
-  await functionsStore.get_functions()
-  availableFunctions.value = functionsStore.functions.map(f => ({ function_id: f.function_id, name: f.name }))
-
   loadForm(route.query.edit)
 })
 
@@ -188,8 +152,6 @@ onBeforeRouteUpdate((to) => {
 // --- Al desmontar ---
 onBeforeUnmount(() => {
   microservicesStore.resetForm()
-  selectedServiceId.value = ''
-  selectedFunctions.value = []
   formRef.value.resetValidation()
   isValid.value = false
 })
@@ -212,13 +174,10 @@ const save = async () => {
       color: 'success'
     }
 
-    formRef.value.resetValidation()
-
     if (!isEditing.value) {
-      isValid.value = false
       microservicesStore.resetForm()
-      selectedServiceId.value = ''
-      selectedFunctions.value = []
+      isValid.value = false
+      formRef.value.resetValidation()
     }
   } else {
     snackbar.value = { show: true, text: 'Error: ' + result.message, color: 'error' }

--- a/src/store/microservices.js
+++ b/src/store/microservices.js
@@ -11,8 +11,7 @@ export const useMicroservicesStore = defineStore("microservices", () => {
   const form = ref({
     name: "",
     service_id: "",
-    resources: { cpu: 0, ram: "" },
-    functions: []
+    resources: { cpu: 0, ram: "" }
   });
 
   const loading = ref(false);
@@ -21,8 +20,7 @@ export const useMicroservicesStore = defineStore("microservices", () => {
     form.value = {
       name: "",
       service_id: "",
-      resources: { cpu: 0, ram: "" },
-      functions: []
+      resources: { cpu: 0, ram: "" }
     };
   }
 

--- a/src/views/microservices.vue
+++ b/src/views/microservices.vue
@@ -25,7 +25,7 @@
             v-for="(ms, index) in filteredMicroservices"
             :key="ms.service_id"
             :title="`Microservice: ${ms.name}`"
-            :description="`CPU: ${ms.resources.cpu} | RAM: ${ms.resources.ram} | Functions: ${ms.functions.length}`"
+            :description="`CPU: ${ms.resources.cpu} | RAM: ${ms.resources.ram}`"
             :autor="ms.created_at"
             :image="microser"
           >


### PR DESCRIPTION
### Descripción
Se elimina el campo `functions` del formulario de creación de microservicios. Esto evita confusión para el usuario final y simplifica la UI.

### Cambios realizados
- Se removió el `<v-select>` de funciones del formulario.
- El payload de creación/actualización de microservicios ya no incluye `functions`.
- Se mantiene la creación y actualización de microservicios funcionando correctamente.
- Se ajustó el formulario para que se limpie correctamente después de crear un microservicio sin mostrar errores de validación.


